### PR TITLE
fix: moved drawer trigger outside drawer root

### DIFF
--- a/src/components/ui/drawer-sheet.tsx
+++ b/src/components/ui/drawer-sheet.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { Fragment, useState } from "react";
+import { Slot } from "radix-ui";
 
 import { cn } from "@/lib/utils/cn";
 import {
@@ -7,7 +8,6 @@ import {
   DrawerDescription,
   DrawerHeader,
   DrawerTitle,
-  DrawerTrigger,
 } from "@/components/ui/drawer";
 
 type PointerDownOutsideEvent = CustomEvent<{
@@ -39,24 +39,49 @@ const DrawerSheet = ({
   onPointerDownOutside,
   onOpenAutoFocus,
 }: Props) => {
-  return (
-    <Drawer open={open} onOpenChange={onOpenChange}>
-      {trigger && <DrawerTrigger asChild>{trigger}</DrawerTrigger>}
-      <DrawerContent
-        className={className}
-        onPointerDownOutside={onPointerDownOutside}
-        onOpenAutoFocus={onOpenAutoFocus}
-      >
-        <DrawerHeader
-          className={cn({ "sr-only": !title && !description }, headerClassName)}
-        >
-          <DrawerTitle>{title}</DrawerTitle>
-          <DrawerDescription>{description}</DrawerDescription>
-        </DrawerHeader>
+  const [controlOpen, setControlOpen] = useState(!!open);
 
-        {children}
-      </DrawerContent>
-    </Drawer>
+  const handleOpenChange = (value: boolean) => {
+    setControlOpen(value);
+    onOpenChange?.(value);
+  };
+
+  return (
+    <Fragment>
+      {/* We've observed a weird issue with the drawer in standalone mode when the trigger is inside the drawer.
+       * The drawer was jarring, not allowing users to interact with the content.
+       * This behavior was observed in two scenarios:
+       * 1. When the content of the page exceeds the viewport height and user scroll through the content then attempt to interact with the trigger.
+       *    The drawer could open but won't close again.
+       * 2. When the drawer is opened inside the columns array of tanstack table. The drawer was misbehaving, content jarring, not allowing user to interact.
+       *    Clicking anywhere inside the drawer was causing triggering actions that were not intended and also re-rendering content outside the drawer.
+       *
+       * To fix this, we're moving the trigger outside the drawer and wrap it in a slot. At least this way the weird behavior is contained.
+       */}
+      {trigger && (
+        <Slot.Root onClick={() => handleOpenChange(true)}>{trigger}</Slot.Root>
+      )}
+
+      <Drawer open={controlOpen} onOpenChange={handleOpenChange}>
+        <DrawerContent
+          className={className}
+          onPointerDownOutside={onPointerDownOutside}
+          onOpenAutoFocus={onOpenAutoFocus}
+        >
+          <DrawerHeader
+            className={cn(
+              { "sr-only": !title && !description },
+              headerClassName,
+            )}
+          >
+            <DrawerTitle>{title}</DrawerTitle>
+            <DrawerDescription>{description}</DrawerDescription>
+          </DrawerHeader>
+
+          {children}
+        </DrawerContent>
+      </Drawer>
+    </Fragment>
   );
 };
 

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -8,7 +8,13 @@ import { cn } from "@/lib/utils/cn";
 function Drawer({
   ...props
 }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
-  return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
+  return (
+    <DrawerPrimitive.Root
+      data-slot="drawer"
+      repositionInputs={false}
+      {...props}
+    />
+  );
 }
 
 function DrawerTrigger({

--- a/src/features/portfolio/components/PortfolioDrawer.tsx
+++ b/src/features/portfolio/components/PortfolioDrawer.tsx
@@ -1,5 +1,7 @@
+import { Fragment, useState } from "react";
 import dynamic from "next/dynamic";
-import { ArrowLeft, ArrowRight } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
+import { Slot } from "radix-ui";
 
 import {
   Drawer,
@@ -30,42 +32,42 @@ const PortfolioFees = dynamic(() => import("./PortfolioFees"), {
   ),
 });
 
-type Props = {
-  open?: boolean;
-  trigger?: React.ReactNode;
-  onOpenChange?: (open: boolean) => void;
-};
+const PortfolioDrawer = ({ trigger }: { trigger: React.ReactNode }) => {
+  const [open, setOpen] = useState(false);
 
-const PortfolioDrawer = ({ open, trigger, onOpenChange }: Props) => {
   return (
-    <Drawer open={open} onOpenChange={onOpenChange} direction="right">
-      <DrawerTrigger asChild>{trigger}</DrawerTrigger>
-      <DrawerContent className="w-full! border-l-0! px-0 standalone:pt-safe-top overflow-y-auto overflow-x-hidden">
-        <DrawerHeader className="sticky top-0 z-10 bg-primary-dark gap-0 p-4">
-          <DrawerTitle className="w-full flex items-center justify-center gap-2">
-            <DrawerClose asChild>
-              <ArrowLeft className="size-5" />
-            </DrawerClose>
-            <p className="flex-1 text-center text-base text-white font-semibold">
-              Portfolio
-            </p>
-          </DrawerTitle>
-          <DrawerDescription className="sr-only">
-            Showing user's portfolio
-          </DrawerDescription>
-        </DrawerHeader>
-        <div className="w-full space-y-2">
-          <div className="w-full flex flex-col md:flex-row items-stretch gap-2 px-4">
-            <PortfolioOverview />
-            <PortfolioChart />
-          </div>
+    <Fragment>
+      <Slot.Root data-slot="drawer-trigger" onClick={() => setOpen(true)}>
+        {trigger}
+      </Slot.Root>
+      <Drawer open={open} onOpenChange={setOpen} direction="right">
+        <DrawerContent className="w-full! border-l-0! px-0 standalone:pt-safe-top overflow-y-auto overflow-x-hidden">
+          <DrawerHeader className="sticky top-0 z-10 bg-primary-dark gap-0 p-4">
+            <DrawerTitle className="w-full flex items-center justify-center gap-2">
+              <DrawerClose asChild>
+                <ArrowLeft className="size-5" />
+              </DrawerClose>
+              <p className="flex-1 text-center text-base text-white font-semibold">
+                Portfolio
+              </p>
+            </DrawerTitle>
+            <DrawerDescription className="sr-only">
+              Showing user's portfolio
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="w-full space-y-2">
+            <div className="w-full flex flex-col md:flex-row items-stretch gap-2 px-4">
+              <PortfolioOverview />
+              <PortfolioChart />
+            </div>
 
-          <div className="px-4">
-            <PortfolioFees />
+            <div className="px-4">
+              <PortfolioFees />
+            </div>
           </div>
-        </div>
-      </DrawerContent>
-    </Drawer>
+        </DrawerContent>
+      </Drawer>
+    </Fragment>
   );
 };
 

--- a/src/features/swap/components/SwapDrawer.tsx
+++ b/src/features/swap/components/SwapDrawer.tsx
@@ -1,4 +1,6 @@
+import { Fragment, useState } from "react";
 import { ArrowLeft } from "lucide-react";
+import { Slot } from "radix-ui";
 
 import {
   Drawer,
@@ -7,45 +9,48 @@ import {
   DrawerDescription,
   DrawerHeader,
   DrawerTitle,
-  DrawerTrigger,
 } from "@/components/ui/drawer";
 
 import SettingsTrigger from "./SettingsTrigger";
 import SwapForm from "./SwapForm";
 
 type Props = {
-  open?: boolean;
-  trigger?: React.ReactNode;
-  onOpenChange?: (open: boolean) => void;
+  trigger: React.ReactNode;
 };
 
-const SwapDrawer = ({ open, trigger, onOpenChange }: Props) => {
+const SwapDrawer = ({ trigger }: Props) => {
+  const [open, setOpen] = useState(false);
+
   return (
-    <Drawer open={open} onOpenChange={onOpenChange} direction="right">
-      <DrawerTrigger asChild>{trigger}</DrawerTrigger>
-      <DrawerContent className="px-0 pt-4 standalone:pt-safe-top">
-        <div
-          id="swap-container"
-          className="w-full max-w-116.25 mx-auto px-4 md:px-2 md:pb-4"
-        >
-          <DrawerHeader className="sticky top-0 z-10 bg-primary-dark gap-0 p-0 mb-4">
-            <DrawerTitle className="w-full flex items-center justify-between gap-2">
-              <DrawerClose asChild>
-                <ArrowLeft className="size-5" />
-              </DrawerClose>
-              <p className="text-base text-white font-semibold">Swap</p>
-              <SettingsTrigger />
-            </DrawerTitle>
+    <Fragment>
+      <Slot.Root data-slot="drawer-trigger" onClick={() => setOpen(true)}>
+        {trigger}
+      </Slot.Root>
+      <Drawer open={open} onOpenChange={setOpen} direction="right">
+        <DrawerContent className="px-0 pt-4 standalone:pt-safe-top">
+          <div
+            id="swap-container"
+            className="w-full max-w-116.25 mx-auto px-4 md:px-2 md:pb-4"
+          >
+            <DrawerHeader className="sticky top-0 z-10 bg-primary-dark gap-0 p-0 mb-4">
+              <DrawerTitle className="w-full flex items-center justify-between gap-2">
+                <DrawerClose asChild>
+                  <ArrowLeft className="size-5" />
+                </DrawerClose>
+                <p className="text-base text-white font-semibold">Swap</p>
+                <SettingsTrigger />
+              </DrawerTitle>
 
-            <DrawerDescription className="sr-only">
-              Swap any spot assets
-            </DrawerDescription>
-          </DrawerHeader>
+              <DrawerDescription className="sr-only">
+                Swap any spot assets
+              </DrawerDescription>
+            </DrawerHeader>
 
-          <SwapForm />
-        </div>
-      </DrawerContent>
-    </Drawer>
+            <SwapForm />
+          </div>
+        </DrawerContent>
+      </Drawer>
+    </Fragment>
   );
 };
 

--- a/src/features/trade/components/TradingAccountPanel/CardItem.tsx
+++ b/src/features/trade/components/TradingAccountPanel/CardItem.tsx
@@ -4,13 +4,15 @@ const CardItem = ({
   label,
   value,
   className,
-}: {
+  ...props
+}: React.ComponentProps<"div"> & {
   label: React.ReactNode;
   value: React.ReactNode;
   className?: string;
 }) => {
   return (
     <div
+      {...props}
       className={cn(
         "flex-1 last:flex last:flex-col last:items-end space-y-0.5 text-white",
         className,

--- a/src/features/trade/components/TradingAccountPanel/Positions/AdjustIsolatedMargin.tsx
+++ b/src/features/trade/components/TradingAccountPanel/Positions/AdjustIsolatedMargin.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { useAccountTransactStore } from "@/lib/store/trade/account-transact";
 import { useShallowUserTradeStore } from "@/lib/store/trade/user-trade";
 import { Position } from "@/lib/types/trade";
@@ -13,23 +15,27 @@ import { roundToDecimals } from "@/features/trade/utils";
 
 type Props = {
   position: Position;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
+  trigger: React.ReactNode;
 };
 
-const AdjustIsolatedMargin = ({ position, open, onOpenChange }: Props) => {
+const AdjustIsolatedMargin = ({ position, trigger }: Props) => {
+  const [open, setOpen] = useState(false);
+
+  if (position.leverage.type !== "isolated") return trigger;
+
   return (
     <AdaptiveDialog
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={setOpen}
       title="Adjust Margin"
       description="Add margin to keep your position safer and lower the risk of liquidation or reduce extra margin to use for other positions."
       className="gap-1"
       headerClassName="gap-3"
+      trigger={trigger}
     >
       <AdjustIsolatedMarginContent
         position={position}
-        onSuccess={() => onOpenChange?.(false)}
+        onSuccess={() => setOpen(false)}
       />
     </AdaptiveDialog>
   );

--- a/src/features/trade/components/TradingAccountPanel/Positions/CloseAllPositions.tsx
+++ b/src/features/trade/components/TradingAccountPanel/Positions/CloseAllPositions.tsx
@@ -12,22 +12,19 @@ import { useClosePosition } from "@/features/trade/hooks/useClosePosition";
 import { useFeeRate } from "@/features/trade/hooks/useUserFees";
 
 type Props = {
-  open?: boolean;
-  trigger?: React.ReactNode;
   positions: Position[];
-  onOpenChange?: (open: boolean) => void;
 };
 
-const CloseAllPositions = ({
-  open,
-  positions,
-  trigger,
-  onOpenChange,
-}: Props) => {
+const CloseAllPositions = ({ positions }: Props) => {
+  const [open, setOpen] = useState(false);
+
   return (
     <AdaptiveDialog
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={(open) => {
+        if (!positions.length) return;
+        setOpen(open);
+      }}
       title={"Close all positions"}
       description={
         <span className="text-xs text-neutral-gray-400">
@@ -35,12 +32,20 @@ const CloseAllPositions = ({
           orders
         </span>
       }
-      trigger={trigger}
+      trigger={
+        <p
+          className={cn("text-primary text-xs font-medium cursor-pointer", {
+            "text-neutral-gray-400": !positions.length,
+          })}
+        >
+          Close All
+        </p>
+      }
       className="gap-1"
     >
       <CloseAllPositionContent
         positions={positions}
-        onSuccess={() => onOpenChange?.(false)}
+        onSuccess={() => setOpen(false)}
       />
     </AdaptiveDialog>
   );

--- a/src/features/trade/components/TradingAccountPanel/Positions/ClosePosition.tsx
+++ b/src/features/trade/components/TradingAccountPanel/Positions/ClosePosition.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useReducer } from "react";
+import { useMemo, useReducer, useState } from "react";
 
 import { Position } from "@/lib/types/trade";
 import { cn } from "@/lib/utils/cn";
@@ -20,9 +20,8 @@ import {
 } from "@/features/trade/utils";
 
 type Props = {
-  open?: boolean;
   position: Position;
-  onOpenChange?: (open: boolean) => void;
+  trigger: React.ReactNode;
 };
 
 type State = {
@@ -43,17 +42,19 @@ const getMidPrice = (midPx: string, pxDecimals: number) => {
   return roundToDecimals(mid, pxDecimals, "floor").toString();
 };
 
-const ClosePosition = ({ position, open, onOpenChange }: Props) => {
+const ClosePosition = ({ position, trigger }: Props) => {
+  const [open, setOpen] = useState(false);
   return (
     <AdaptiveDialog
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={setOpen}
       title={`Close Position (${position.coin})`}
+      trigger={trigger}
       className="gap-1"
     >
       <ClosePositionContent
         position={position}
-        onSuccess={() => onOpenChange?.(false)}
+        onSuccess={() => setOpen(false)}
       />
     </AdaptiveDialog>
   );

--- a/src/features/trade/components/TradingAccountPanel/Positions/Columns.tsx
+++ b/src/features/trade/components/TradingAccountPanel/Positions/Columns.tsx
@@ -10,11 +10,14 @@ import { formatNumber } from "@/lib/utils/formatting/numbers";
 import { formatPriceToDecimal } from "@/features/trade/utils";
 
 import CoinLink from "../CoinLink";
+import AdjustIsolatedMargin from "./AdjustIsolatedMargin";
+import CloseAllPositions from "./CloseAllPositions";
+import ClosePosition from "./ClosePosition";
+import ReversePosition from "./ReversePosition";
+import TriggerPrice from "./TriggerPrice";
 
 export type PositionTableMeta = {
   positions: Position[];
-  setCurrentPosition: (position: Position, action: PositionAction) => void;
-  setOpenCloseAll: (open: boolean) => void;
 };
 
 export const POSITION_COLUMNS: ColumnDef<Position>[] = [
@@ -159,28 +162,30 @@ export const POSITION_COLUMNS: ColumnDef<Position>[] = [
   {
     id: "margin",
     header: "Margin",
-    cell({ row: { original }, table }) {
-      const { setCurrentPosition } = table.options
-        .meta as unknown as PositionTableMeta;
+    cell({ row: { original } }) {
       return (
-        <div
-          onClick={() => setCurrentPosition(original, "margin")}
-          className={cn("space-x-0.5 flex items-center", {
-            "underline decoration-dashed cursor-pointer":
-              original.leverage.type === "isolated",
-          })}
-        >
-          <p>
-            {formatNumber(Number(original.marginUsed), {
-              style: "currency",
-              useFallback: true,
-            })}
-          </p>
-          <p className="capitalize">({original.leverage.type})</p>
-          {original.leverage.type === "isolated" && (
-            <ChevronRight className="size-3.5 stroke-3 text-neutral-gray-400" />
-          )}
-        </div>
+        <AdjustIsolatedMargin
+          position={original}
+          trigger={
+            <div
+              className={cn("space-x-0.5 flex items-center", {
+                "underline decoration-dashed cursor-pointer":
+                  original.leverage.type === "isolated",
+              })}
+            >
+              <p>
+                {formatNumber(Number(original.marginUsed), {
+                  style: "currency",
+                  useFallback: true,
+                })}
+              </p>
+              <p className="capitalize">({original.leverage.type})</p>
+              {original.leverage.type === "isolated" && (
+                <ChevronRight className="size-3.5 stroke-3 text-neutral-gray-400" />
+              )}
+            </div>
+          }
+        />
       );
     },
   },
@@ -212,37 +217,29 @@ export const POSITION_COLUMNS: ColumnDef<Position>[] = [
   {
     id: "closeAll",
     header({ table }) {
-      const { positions, setOpenCloseAll } = table.options
-        .meta as unknown as PositionTableMeta;
+      const { positions } = table.options.meta as unknown as PositionTableMeta;
 
-      return (
-        <p
-          onClick={() => positions.length && setOpenCloseAll(true)}
-          className={cn("text-primary text-xs font-medium cursor-pointer", {
-            "text-neutral-gray-400": !positions.length,
-          })}
-        >
-          Close All
-        </p>
-      );
+      return <CloseAllPositions positions={positions} />;
     },
-    cell({ row: { original }, table }) {
-      const { setCurrentPosition } = table.options
-        .meta as unknown as PositionTableMeta;
+    cell({ row: { original } }) {
       return (
         <div className="flex items-center gap-x-2">
-          <p
-            onClick={() => setCurrentPosition(original, "close")}
-            className="text-primary text-xs font-medium cursor-pointer"
-          >
-            Close
-          </p>
-          <p
-            onClick={() => setCurrentPosition(original, "reverse")}
-            className="text-primary text-xs font-medium cursor-pointer"
-          >
-            Reverse
-          </p>
+          <ClosePosition
+            position={original}
+            trigger={
+              <p className="text-primary text-xs font-medium cursor-pointer">
+                Close
+              </p>
+            }
+          />
+          <ReversePosition
+            position={original}
+            trigger={
+              <p className="text-primary text-xs font-medium cursor-pointer">
+                Reverse
+              </p>
+            }
+          />
         </div>
       );
     },
@@ -250,7 +247,7 @@ export const POSITION_COLUMNS: ColumnDef<Position>[] = [
   {
     id: "tpsl",
     header: "TP/SL",
-    cell({ row: { original }, table }) {
+    cell({ row: { original } }) {
       const formattedTpPrice = formatPriceToDecimal(
         Number(original.tpPrice || "0"),
         original.pxDecimals,
@@ -263,31 +260,29 @@ export const POSITION_COLUMNS: ColumnDef<Position>[] = [
       );
 
       return (
-        <div
-          onClick={() =>
-            (
-              table.options.meta as unknown as PositionTableMeta
-            ).setCurrentPosition(original, "tpsl")
-          }
-          className="flex items-center gap-x-1 cursor-pointer"
-        >
-          <p
-            onClick={(e) => {
-              e.preventDefault();
+        <TriggerPrice
+          position={original}
+          trigger={
+            <div className="flex items-center gap-x-1 cursor-pointer">
+              <p
+                onClick={(e) => {
+                  e.preventDefault();
 
-              usePreferencesStore
-                .getState()
-                .dispatch({ activeTab: "openOrders" });
-            }}
-            className={cn({
-              "border-b border-transparent hover:border-primary hover:text-primary":
-                !!original.tpPrice || !!original.slPrice,
-            })}
-          >
-            {formattedTpPrice}/{formattedSlPrice}
-          </p>
-          <Pen className="size-4 text-primary" />
-        </div>
+                  usePreferencesStore
+                    .getState()
+                    .dispatch({ activeTab: "openOrders" });
+                }}
+                className={cn({
+                  "border-b border-transparent hover:border-primary hover:text-primary":
+                    !!original.tpPrice || !!original.slPrice,
+                })}
+              >
+                {formattedTpPrice}/{formattedSlPrice}
+              </p>
+              <Pen className="size-4 text-primary" />
+            </div>
+          }
+        />
       );
     },
   },

--- a/src/features/trade/components/TradingAccountPanel/Positions/PositionCard.tsx
+++ b/src/features/trade/components/TradingAccountPanel/Positions/PositionCard.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { ChevronRight } from "lucide-react";
 
 import { ROUTES } from "@/lib/constants/routes";
-import { Position, PositionAction } from "@/lib/types/trade";
+import { Position } from "@/lib/types/trade";
 import { cn } from "@/lib/utils/cn";
 import { formatNumber } from "@/lib/utils/formatting/numbers";
 import TokenImage from "@/components/common/TokenImage";
@@ -11,12 +11,15 @@ import Tag from "@/components/ui/tag";
 import { formatPriceToDecimal } from "@/features/trade/utils";
 
 import CardItem from "../CardItem";
+import AdjustIsolatedMargin from "./AdjustIsolatedMargin";
+import ClosePosition from "./ClosePosition";
+import ReversePosition from "./ReversePosition";
+import TriggerPrice from "./TriggerPrice";
 
 type Props = {
   data: Position;
-  onActionClick: (position: Position, action: PositionAction) => void;
 };
-const PositionCard = ({ data, onActionClick }: Props) => {
+const PositionCard = ({ data }: Props) => {
   const unrealizedPnl = Number(data.unrealizedPnl);
   const returnOnEquity = Number(data.returnOnEquity);
 
@@ -91,25 +94,31 @@ const PositionCard = ({ data, onActionClick }: Props) => {
           label="Mark Price"
           value={formatPriceToDecimal(Number(data.markPx), data.pxDecimals)}
         />
-        <CardItem
-          label={
-            <div
-              className="flex items-center gap-x-0.5"
-              onClick={() =>
-                data.leverage.type === "isolated" &&
-                onActionClick(data, "margin")
+
+        <AdjustIsolatedMargin
+          position={data}
+          trigger={
+            <CardItem
+              label={
+                <div
+                  className="flex items-center gap-x-0.5"
+                  // onClick={() =>
+                  //   data.leverage.type === "isolated" &&
+                  //   onActionClick(data, "margin")
+                  // }
+                >
+                  <span>Margin</span>
+                  {data.leverage.type === "isolated" && (
+                    <ChevronRight className="size-3" />
+                  )}
+                </div>
               }
-            >
-              <span>Margin</span>
-              {data.leverage.type === "isolated" && (
-                <ChevronRight className="size-3" />
-              )}
-            </div>
+              value={formatNumber(Number(data.marginUsed), {
+                style: "currency",
+                useFallback: true,
+              })}
+            />
           }
-          value={formatNumber(Number(data.marginUsed), {
-            style: "currency",
-            useFallback: true,
-          })}
         />
         <CardItem
           label="Funding"
@@ -133,26 +142,38 @@ const PositionCard = ({ data, onActionClick }: Props) => {
       </div>
 
       <div className="mt-2 grid grid-cols-3 gap-2">
-        <Button
-          variant="secondary"
-          size="sm"
-          className="h-7 text-xs text-white"
-          label="Close Position"
-          onClick={() => onActionClick(data, "close")}
+        <ClosePosition
+          position={data}
+          trigger={
+            <Button
+              variant="secondary"
+              size="sm"
+              className="h-7 text-xs text-white"
+              label="Close Position"
+            />
+          }
         />
-        <Button
-          variant="secondary"
-          size="sm"
-          className="h-7 text-xs text-white"
-          label="Reverse"
-          onClick={() => onActionClick(data, "reverse")}
+        <ReversePosition
+          position={data}
+          trigger={
+            <Button
+              variant="secondary"
+              size="sm"
+              className="h-7 text-xs text-white"
+              label="Reverse"
+            />
+          }
         />
-        <Button
-          variant="secondary"
-          size="sm"
-          className="h-7 text-xs text-white"
-          label="TP/SL"
-          onClick={() => onActionClick(data, "tpsl")}
+        <TriggerPrice
+          position={data}
+          trigger={
+            <Button
+              variant="secondary"
+              size="sm"
+              className="h-7 text-xs text-white"
+              label="TP/SL"
+            />
+          }
         />
       </div>
     </div>

--- a/src/features/trade/components/TradingAccountPanel/Positions/ReversePosition.tsx
+++ b/src/features/trade/components/TradingAccountPanel/Positions/ReversePosition.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { ArrowDown } from "lucide-react";
 
 import { Position } from "@/lib/types/trade";
@@ -13,21 +14,23 @@ import { formatPriceToDecimal } from "@/features/trade/utils";
 
 type Props = {
   position: Position;
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
+  trigger: React.ReactNode;
 };
 
-const ReversePosition = ({ position, open, onOpenChange }: Props) => {
+const ReversePosition = ({ position, trigger }: Props) => {
+  const [open, setOpen] = useState(false);
+
   return (
     <AdaptiveDialog
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={setOpen}
       title={`Reverse Position (${position.base})`}
+      trigger={trigger}
       className="gap-1"
     >
       <ReversePositionContent
         position={position}
-        onSuccess={() => onOpenChange?.(false)}
+        onSuccess={() => setOpen(false)}
       />
     </AdaptiveDialog>
   );

--- a/src/features/trade/components/TradingAccountPanel/Positions/TriggerPrice.tsx
+++ b/src/features/trade/components/TradingAccountPanel/Positions/TriggerPrice.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useReducer } from "react";
+import { useMemo, useReducer, useState } from "react";
 
 import { Position } from "@/lib/types/trade";
 import { cn } from "@/lib/utils/cn";
@@ -26,9 +26,8 @@ import {
 } from "@/features/trade/utils";
 
 type Props = {
-  open?: boolean;
   position: Position;
-  onOpenChange?: (open: boolean) => void;
+  trigger: React.ReactNode;
 };
 
 type GainMode = "roi" | "pnl";
@@ -45,11 +44,14 @@ type State = {
   currentTab: "full" | "partial";
 };
 
-const TriggerPrice = ({ position, open, onOpenChange }: Props) => {
+const TriggerPrice = ({ position, trigger }: Props) => {
+  const [open, setOpen] = useState(false);
+
   return (
     <AdaptiveDialog
       open={open}
-      onOpenChange={onOpenChange}
+      onOpenChange={setOpen}
+      trigger={trigger}
       title={
         <div className="flex items-center gap-x-2">
           <span>Set Trigger Price ({position.base})</span>
@@ -71,7 +73,7 @@ const TriggerPrice = ({ position, open, onOpenChange }: Props) => {
     >
       <TriggerPriceContent
         position={position}
-        onSuccess={() => onOpenChange?.(false)}
+        onSuccess={() => setOpen(false)}
       />
     </AdaptiveDialog>
   );

--- a/src/features/trade/components/TradingAccountPanel/Positions/index.tsx
+++ b/src/features/trade/components/TradingAccountPanel/Positions/index.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useMemo, useRef, useState } from "react";
+import { useMemo } from "react";
 
 import { useShallowInstrumentStore } from "@/lib/store/trade/instrument";
 import { useShallowUserTradeStore } from "@/lib/store/trade/user-trade";
-import { Position, PositionAction } from "@/lib/types/trade";
+import { Position } from "@/lib/types/trade";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import Visibility from "@/components/common/Visibility";
 import AdaptiveDataTable from "@/components/ui/adaptive-datatable";
@@ -14,21 +14,12 @@ import {
 } from "@/features/trade/utils";
 import { isStopLoss, isTakeProfit } from "@/features/trade/utils/orderTypes";
 
-import AdjustIsolatedMargin from "./AdjustIsolatedMargin";
 import CloseAllPositions from "./CloseAllPositions";
-import ClosePosition from "./ClosePosition";
-import { POSITION_COLUMNS, PositionTableMeta } from "./Columns";
+import { POSITION_COLUMNS } from "./Columns";
 import PositionCard from "./PositionCard";
-import ReversePosition from "./ReversePosition";
-import TriggerPrice from "./TriggerPrice";
 
 const Positions = () => {
   const isMobile = useIsMobile();
-  const [positionAction, setPositionAction] = useState<PositionAction | null>(
-    null,
-  );
-  const [openCloseAll, setOpenCloseAll] = useState(false);
-
   const { perpMetas, spotMeta } = useAssetMetas();
   const { positions, openOrders } = useShallowUserTradeStore((s) => ({
     positions: s.allDexsClearinghouseState?.assetPositions,
@@ -37,7 +28,6 @@ const Positions = () => {
 
   const allDexsAssetCtxs = useShallowInstrumentStore((s) => s.allDexsAssetCtxs);
 
-  const currentPosition = useRef<Position>(null);
   const hasAssetPositions = !!positions?.length;
 
   const perpsToTpslOrders = useMemo(() => {
@@ -158,45 +148,21 @@ const Positions = () => {
     return assetPositions;
   }, [positions, allDexsAssetCtxs, perpsTokensToInfo, perpsToTpslOrders]);
 
-  const setCurrentPosition = useCallback(
-    (position: Position, type: PositionAction) => {
-      currentPosition.current = position;
-      setPositionAction(type);
-    },
-    [],
-  );
-
-  const onCloseModal = useCallback((open: boolean) => {
-    if (!open) {
-      currentPosition.current = null;
-      setPositionAction(null);
-    }
-  }, []);
-
   return (
     <div className="w-full">
       <Visibility visible={isMobile && !!data.length}>
         <div className="w-full flex md:hidden justify-end pt-2 px-4">
-          <p
-            onClick={() => setOpenCloseAll(true)}
-            className="text-primary text-xs font-medium cursor-pointer"
-          >
-            Close All
-          </p>
+          <CloseAllPositions positions={data} />
         </div>
       </Visibility>
       <AdaptiveDataTable
         columns={POSITION_COLUMNS}
         data={data}
-        meta={
-          {
-            // We're passing positions here so that we can grab them inside the header
-            // Good for performance. Better than calling table.getRowModel().rows inside header
-            positions: data,
-            setCurrentPosition,
-            setOpenCloseAll,
-          } as PositionTableMeta
-        }
+        meta={{
+          // We're passing positions here so that we can grab them inside the header
+          // Good for performance. Better than calling table.getRowModel().rows inside header
+          positions: data,
+        }}
         loading={false}
         initialState={{
           pagination: {
@@ -209,52 +175,9 @@ const Positions = () => {
         thClassName="h-8 py-0 font-medium text-xs"
         rowClassName="text-xs font-medium whitespace-nowrap py-0"
         rowCellClassName="py-1"
-        render={(entry) => (
-          <PositionCard data={entry} onActionClick={setCurrentPosition} />
-        )}
+        render={(entry) => <PositionCard data={entry} />}
         noData="No open positions yet"
         disablePagination
-      />
-
-      {/* In standalone mode the drawers were not responding smoothly to user interactions.
-       * The inputs inside the drawers when requiring at leat two and more clicks to gain focus.
-       * Sliding down to close the drawer was skipping some pixels causing the interaction to lag.
-       * Clicking anywhere inside the drawer was triggering a re-render on the elements outside the drawer.
-       * To resolve those issues we decided to move the drawers outside the columns and card components.
-       * Update: Close All button was not working in standalone mode even when it's being rendered outside the columns component on mobile.
-       * The issue was observed when there is a pixel shift on the TradingAccountActivity panel. For instance when scrolling through TWAPs history
-       * and the tabs list is sticky. Switching to positions tab when the list is not filling the remaining space would cause the Close All positions drawer to misbehave.
-       
-       * Issue observed on iPhone in standalone mode.
-       */}
-      {currentPosition.current && (
-        <>
-          <ReversePosition
-            position={currentPosition.current}
-            open={positionAction === "reverse"}
-            onOpenChange={onCloseModal}
-          />
-          <ClosePosition
-            position={currentPosition.current}
-            open={positionAction === "close"}
-            onOpenChange={onCloseModal}
-          />
-          <TriggerPrice
-            position={currentPosition.current}
-            open={positionAction === "tpsl"}
-            onOpenChange={onCloseModal}
-          />
-          <AdjustIsolatedMargin
-            position={currentPosition.current}
-            open={positionAction === "margin"}
-            onOpenChange={onCloseModal}
-          />
-        </>
-      )}
-      <CloseAllPositions
-        positions={data}
-        open={openCloseAll}
-        onOpenChange={setOpenCloseAll}
       />
     </div>
   );

--- a/src/features/trade/components/TradingAccountPanel/TradingAccountActivity/TradingAccountActivityDrawer.tsx
+++ b/src/features/trade/components/TradingAccountPanel/TradingAccountActivity/TradingAccountActivityDrawer.tsx
@@ -10,7 +10,6 @@ import {
   DrawerDescription,
   DrawerHeader,
   DrawerTitle,
-  DrawerTrigger,
 } from "@/components/ui/drawer";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import AuthenticatedContent from "@/features/trade/components/AuthenticatedContent";
@@ -21,11 +20,6 @@ const TradingAccountDataTable = dynamic(
   { ssr: false },
 );
 
-type Props = {
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
-};
-
 const ACCOUNT_ACTIVITY_TABS = [
   { label: "All", value: "all" },
   { label: "Deposits", value: "deposit" },
@@ -35,9 +29,33 @@ const ACCOUNT_ACTIVITY_TABS = [
   { label: "Vaults", value: "vault" },
 ] as const;
 
-const TradingAccountActivityDrawer = ({ open, onOpenChange }: Props) => {
-  const [filterBy, setFilterBy] = useState("all");
+const TradingAccountActivityDrawer = () => {
   const haptic = useWebHaptics();
+
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <History
+        type="button"
+        data-slot="drawer-trigger"
+        onClick={() => {
+          setOpen(true);
+          haptic.trigger("selection");
+        }}
+        className="size-4.5 text-white"
+      />
+      <Drawer open={open} onOpenChange={setOpen} direction="right">
+        <DrawerContent className="w-full! border-l-0! px-0 standalone:pt-safe-top pb-0">
+          <TradingAccountActivityContent />
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+};
+
+const TradingAccountActivityContent = () => {
+  const [filterBy, setFilterBy] = useState("all");
 
   const { data, status } = useTradingAccountActivity();
 
@@ -47,54 +65,47 @@ const TradingAccountActivityDrawer = ({ open, onOpenChange }: Props) => {
   }, [filterBy, data]);
 
   return (
-    <Drawer open={open} onOpenChange={onOpenChange} direction="right">
-      <DrawerTrigger asChild onClick={() => haptic.trigger("selection")}>
-        <History className="size-4.5 text-white" />
-      </DrawerTrigger>
-      <DrawerContent className="w-full! border-l-0! px-0 standalone:pt-safe-top pb-0">
-        <div className="w-full overflow-y-auto pb-safe-bottom">
-          <div className="w-full sticky top-0 z-10 bg-primary-dark">
-            <DrawerHeader className="p-0">
-              <DrawerTitle className="flex items-center justify-center gap-2 pt-4 px-4">
-                <DrawerClose asChild>
-                  <ArrowLeft className="size-5" />
-                </DrawerClose>
-                <p className="flex-1 text-center text-base text-white font-semibold">
-                  Transaction History
-                </p>
-              </DrawerTitle>
-              <DrawerDescription className="sr-only">
-                Showing user's transactions history
-              </DrawerDescription>
-            </DrawerHeader>
-            <Tabs
-              data-vaul-no-drag
-              defaultValue={filterBy}
-              onValueChange={setFilterBy}
-              className="overflow-x-auto no-scrollbars"
-            >
-              <TabsList variant="line" className="justify-start px-4">
-                {ACCOUNT_ACTIVITY_TABS.map((tab) => (
-                  <TabsTrigger
-                    key={tab.value}
-                    value={tab.value}
-                    className="flex-0 text-xs"
-                  >
-                    {tab.label}
-                  </TabsTrigger>
-                ))}
-              </TabsList>
-            </Tabs>
-          </div>
-          <AuthenticatedContent className="h-20">
-            <TradingAccountDataTable
-              data={filteredActivity}
-              loading={status === "pending"}
-            />
-          </AuthenticatedContent>
-        </div>
-      </DrawerContent>
-    </Drawer>
+    <div className="w-full overflow-y-auto pb-safe-bottom">
+      <div className="w-full sticky top-0 z-10 bg-primary-dark">
+        <DrawerHeader className="p-0">
+          <DrawerTitle className="flex items-center justify-center gap-2 pt-4 px-4">
+            <DrawerClose asChild>
+              <ArrowLeft className="size-5" />
+            </DrawerClose>
+            <p className="flex-1 text-center text-base text-white font-semibold">
+              Transaction History
+            </p>
+          </DrawerTitle>
+          <DrawerDescription className="sr-only">
+            Showing user's transactions history
+          </DrawerDescription>
+        </DrawerHeader>
+        <Tabs
+          data-vaul-no-drag
+          defaultValue={filterBy}
+          onValueChange={setFilterBy}
+          className="overflow-x-auto no-scrollbars"
+        >
+          <TabsList variant="line" className="justify-start px-4">
+            {ACCOUNT_ACTIVITY_TABS.map((tab) => (
+              <TabsTrigger
+                key={tab.value}
+                value={tab.value}
+                className="flex-0 text-xs"
+              >
+                {tab.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+      <AuthenticatedContent className="h-20">
+        <TradingAccountDataTable
+          data={filteredActivity}
+          loading={status === "pending"}
+        />
+      </AuthenticatedContent>
+    </div>
   );
 };
 

--- a/src/features/trade/layouts/mobile/AccountTabView.tsx
+++ b/src/features/trade/layouts/mobile/AccountTabView.tsx
@@ -86,7 +86,7 @@ const AccountTabView = () => {
           trigger={
             <Button
               variant="outline"
-              className="w-full flex items-center justify-center gap-2 border border-neutral-gray-200 rounded-lg text-neutral-gray-400 px-1 py-1.5"
+              className="w-full h-fit flex items-center justify-center gap-2 border border-neutral-gray-200 rounded-lg text-neutral-gray-400 px-1 py-1.5"
             >
               <p className="text-xs font-medium">View portfolio</p>
               <ArrowRight className="size-4" />

--- a/src/features/trade/layouts/mobile/HomeTabView.tsx
+++ b/src/features/trade/layouts/mobile/HomeTabView.tsx
@@ -23,12 +23,11 @@ import Visibility from "@/components/common/Visibility";
 import { Button } from "@/components/ui/button";
 import PortfolioDrawer from "@/features/portfolio/components/PortfolioDrawer";
 import SwapDrawer from "@/features/swap/components/SwapDrawer";
+import PositionsOverview from "@/features/trade/components/TradingAccountPanel/Positions/PositionsOverview";
 import { useAccountBalances } from "@/features/trade/hooks/useAccountBalances";
 import { useAssetsAndContexts } from "@/features/trade/hooks/useAssetAndContexts";
 import { useSelectToken } from "@/features/trade/hooks/useSelectToken";
 import { formatPriceToDecimal, getPriceDecimals } from "@/features/trade/utils";
-
-import PositionsOverview from "../../components/TradingAccountPanel/Positions/PositionsOverview";
 
 const HomeTabView = () => {
   return (

--- a/src/features/trade/layouts/mobile/MarketChartDrawer.tsx
+++ b/src/features/trade/layouts/mobile/MarketChartDrawer.tsx
@@ -1,3 +1,4 @@
+import { Fragment, useState } from "react";
 import { AlignHorizontalDistributeCenter, ArrowLeft } from "lucide-react";
 import { useWebHaptics } from "web-haptics/react";
 
@@ -13,7 +14,6 @@ import {
   DrawerFooter,
   DrawerHeader,
   DrawerTitle,
-  DrawerTrigger,
 } from "@/components/ui/drawer";
 import AssetsSelector from "@/features/trade/components/AssetsSelector";
 import FavoriteButton from "@/features/trade/components/FavoriteButton";
@@ -24,6 +24,7 @@ import { ORDER_FORM_SIDES } from "@/features/trade/constants";
 
 const MarketChartDrawer = () => {
   const haptic = useWebHaptics();
+  const [open, setOpen] = useState(false);
 
   const { coin, isPerps } = useTradeContext((s) => ({
     coin: s.coin,
@@ -31,67 +32,75 @@ const MarketChartDrawer = () => {
   }));
 
   return (
-    <Drawer direction="right">
-      <DrawerTrigger asChild onClick={() => haptic.trigger("medium")}>
-        <AlignHorizontalDistributeCenter className="size-4.5 text-white" />
-      </DrawerTrigger>
-      <DrawerContent className="px-0 pt-4 pb-0 standalone:pt-safe-top">
-        <div className="w-full overflow-y-auto pb-4 standalone:pb-safe-bottom">
-          <DrawerHeader className="sticky top-0 z-10 bg-primary-dark gap-0 px-4 pb-1">
-            <DrawerTitle className="w-full flex items-center justify-between gap-2">
-              <DrawerClose asChild>
-                <ArrowLeft className="size-5" />
-              </DrawerClose>
-              <AssetsSelector
-                showTags
-                showTokenImage={false}
-                className="flex-1 mb-0"
-                symbolClassName="text-base"
-              />
-              <FavoriteButton coin={coin} className="size-5 text-white" />
-            </DrawerTitle>
+    <Fragment>
+      <AlignHorizontalDistributeCenter
+        role="button"
+        data-slot="drawer-trigger"
+        onClick={() => {
+          haptic.trigger("medium");
+          setOpen(true);
+        }}
+        className="size-4.5 text-white"
+      />
+      <Drawer open={open} onOpenChange={setOpen} direction="right">
+        <DrawerContent className="px-0 pt-4 pb-0 standalone:pt-safe-top">
+          <div className="w-full overflow-y-auto pb-4 standalone:pb-safe-bottom">
+            <DrawerHeader className="sticky top-0 z-10 bg-primary-dark gap-0 px-4 pb-1">
+              <DrawerTitle className="w-full flex items-center justify-between gap-2">
+                <DrawerClose asChild>
+                  <ArrowLeft className="size-5" />
+                </DrawerClose>
+                <AssetsSelector
+                  showTags
+                  showTokenImage={false}
+                  className="flex-1 mb-0"
+                  symbolClassName="text-base"
+                />
+                <FavoriteButton coin={coin} className="size-5 text-white" />
+              </DrawerTitle>
 
-            <DrawerDescription className="sr-only">
-              Showing chart of the current market
-            </DrawerDescription>
-          </DrawerHeader>
+              <DrawerDescription className="sr-only">
+                Showing chart of the current market
+              </DrawerDescription>
+            </DrawerHeader>
 
-          <div className="w-full mb-16">
-            <div className="w-full grid grid-cols-2 md:flex md:items-center md:gap-6 bg-primary-dark px-4 py-2 md:rounded-md">
-              <TickerPrice />
+            <div className="w-full mb-16">
+              <div className="w-full grid grid-cols-2 md:flex md:items-center md:gap-6 bg-primary-dark px-4 py-2 md:rounded-md">
+                <TickerPrice />
 
-              <TickerContexts />
+                <TickerContexts />
+              </div>
+
+              <MarketArea />
             </div>
 
-            <MarketArea />
+            <DrawerFooter className="fixed inset-x-0 bottom-4 z-10 pt-2 flex flex-row items-center bg-primary-dark">
+              {Object.entries(ORDER_FORM_SIDES).map(([side, label]) => (
+                <DrawerClose
+                  key={side}
+                  className={cn(
+                    "flex-1 w-full h-10 flex items-center justify-center rounded-lg text-center text-neutral-gray-400 cursor-pointer transition-colors",
+                    {
+                      "bg-sell text-white": side === "sell",
+                      "bg-buy text-white": side === "buy",
+                    },
+                  )}
+                  onClick={() =>
+                    useOrderFormStore
+                      .getState()
+                      .onOrderSideChange(side as OrderSide, !isPerps)
+                  }
+                >
+                  <p className="text-sm font-semibold">
+                    {label[isPerps ? "perp" : "spot"]}
+                  </p>
+                </DrawerClose>
+              ))}
+            </DrawerFooter>
           </div>
-
-          <DrawerFooter className="fixed inset-x-0 bottom-4 z-10 pt-2 flex flex-row items-center bg-primary-dark">
-            {Object.entries(ORDER_FORM_SIDES).map(([side, label]) => (
-              <DrawerClose
-                key={side}
-                className={cn(
-                  "flex-1 w-full h-10 flex items-center justify-center rounded-lg text-center text-neutral-gray-400 cursor-pointer transition-colors",
-                  {
-                    "bg-sell text-white": side === "sell",
-                    "bg-buy text-white": side === "buy",
-                  },
-                )}
-                onClick={() =>
-                  useOrderFormStore
-                    .getState()
-                    .onOrderSideChange(side as OrderSide, !isPerps)
-                }
-              >
-                <p className="text-sm font-semibold">
-                  {label[isPerps ? "perp" : "spot"]}
-                </p>
-              </DrawerClose>
-            ))}
-          </DrawerFooter>
-        </div>
-      </DrawerContent>
-    </Drawer>
+        </DrawerContent>
+      </Drawer>
+    </Fragment>
   );
 };
 


### PR DESCRIPTION
- resolved jarring issue with drawer on mobile by moving the trigger outside the root component
- applied fixes in positions, swap, portfolio and account activity drawers
- set repositionInputs to false to prevent contents from scrolling on mobile when keyboard is open.